### PR TITLE
Notepad: fix File->Exit behavior, menu handling, and .txt open flow

### DIFF
--- a/apps/include/os/ipc.hpp
+++ b/apps/include/os/ipc.hpp
@@ -15,6 +15,7 @@ constexpr int MSG_GFX_WINDOW_CREATED = 2;
 constexpr int MSG_GFX_INVALIDATE_RECT = 3;
 constexpr int MSG_GFX_MOUSE_EVENT = 4;
 constexpr int MSG_GFX_KEY_EVENT = 5;
+constexpr int MSG_GFX_CLOSE_WINDOW = 6;
 
 struct msg_gfx_create_window_t {
   int width;
@@ -41,6 +42,7 @@ struct msg_gfx_mouse_event_t {
 struct msg_gfx_key_event_t {
   int window_id;
   char key;
+  int scancode;
 };
 
 struct gfx_msg_t {
@@ -156,6 +158,17 @@ public:
         put_pixel(x + i, y + j, color);
       }
     }
+  }
+
+  // Send close-window request to window server (same encoding as red X button)
+  void close_window() {
+    if (sock_fd < 0)
+      return;
+    gfx_msg_t msg;
+    msg.type = MSG_GFX_CLOSE_WINDOW;
+    msg.size = 0;
+    msg.data.invalidate.window_id = window_id;
+    Syscall::write(sock_fd, &msg, sizeof(msg));
   }
 };
 } // namespace OS

--- a/apps/include/os/syscalls.hpp
+++ b/apps/include/os/syscalls.hpp
@@ -67,9 +67,9 @@ static inline int execve(const char *path, char **argv, char **envp) {
 }
 
 static inline void exit(int status) {
+  // Prefer POSIX _exit path. If kernel returns unexpectedly, try legacy exit.
+  asm volatile("int $0x80" : : "a"(SYS__EXIT), "b"(status));
   asm volatile("int $0x80" : : "a"(SYS_EXIT), "b"(status));
-  while (1)
-    ;
 }
 
 static inline int wait(int *status) {

--- a/apps/notepad.cpp
+++ b/apps/notepad.cpp
@@ -150,6 +150,7 @@ void init_font8x8() {
 
 #define FONT_W 9
 #define FONT_H 16
+static const char *DEFAULT_NOTE_PATH = "/home/user/Documents/note.txt";
 
 // ---------------------------------------------
 // Text Buffer
@@ -242,41 +243,59 @@ struct TextBuffer {
     s = n;
   }
 
-  void load_file(const char *path) {
+  bool load_file(const char *path) {
     int fd = OS::Syscall::open(path, O_RDONLY);
     if (fd < 0)
-      return;
+      return false;
 
     clear();
     char *buf = new char[32768];
     int n = OS::Syscall::read(fd, buf, 32768);
     OS::Syscall::close(fd);
 
+    if (n < 0) {
+      delete[] buf;
+      return false;
+    }
+
     if (n > 0) {
       for (int i = 0; i < n; i++) {
         if (buf[i] == '\n') {
           add_line("");
-        } else if (buf[i] != '\r') {
+        } else if (buf[i] == '\r') {
+          // ignore
+        } else if ((buf[i] >= 32 && buf[i] <= 126) || buf[i] == '\t') {
           append_char(lines[line_count - 1], buf[i]);
         }
       }
     }
     delete[] buf;
     dirty = false;
+    return true;
   }
 
-  void save_file(const char *path) {
+  bool save_file(const char *path) {
     int fd = OS::Syscall::open(path, O_CREAT | O_WRONLY | O_TRUNC);
     if (fd < 0)
-      return;
+      return false;
 
     for (int i = 0; i < line_count; i++) {
-      OS::Syscall::write(fd, lines[i], my_strlen(lines[i]));
-      if (i < line_count - 1)
-        OS::Syscall::write(fd, "\n", 1);
+      int len = my_strlen(lines[i]);
+      int w = OS::Syscall::write(fd, lines[i], len);
+      if (w != len) {
+        OS::Syscall::close(fd);
+        return false;
+      }
+      if (i < line_count - 1) {
+        if (OS::Syscall::write(fd, "\n", 1) != 1) {
+          OS::Syscall::close(fd);
+          return false;
+        }
+      }
     }
     OS::Syscall::close(fd);
     dirty = false;
+    return true;
   }
 
   char *concat(const char *s1, const char *s2) {
@@ -370,7 +389,7 @@ class NotepadApp {
 public:
   NotepadApp() : ipc(nullptr), width(600), height(400), active_menu(MENU_NONE) {
     my_strcpy(title, "Notepad");
-    current_path[0] = 0;
+    my_strcpy(current_path, DEFAULT_NOTE_PATH);
     status[0] = 0;
   }
   ~NotepadApp() {
@@ -385,6 +404,24 @@ public:
     if (!ipc->create_window(title, width, height))
       return false;
     return true;
+  }
+
+  bool open_path(const char *path) {
+    if (!path || !path[0])
+      return false;
+    my_strcpy(current_path, path);
+    if (buffer.load_file(path)) {
+      // Place cursor at end of loaded content for immediate editing
+      buffer.cursor_row = buffer.line_count - 1;
+      if (buffer.cursor_row < 0)
+        buffer.cursor_row = 0;
+      buffer.cursor_col = my_strlen(buffer.lines[buffer.cursor_row]);
+      my_strcpy(status, "File Opened");
+      return true;
+    }
+    buffer.clear();
+    my_strcpy(status, "New File");
+    return false;
   }
 
   void draw_text(int x, int y, const char *txt, uint32_t color) {
@@ -423,7 +460,7 @@ public:
     if (current_path[0])
       draw_text(200, 4, current_path, 0xFF666666);
     if (status[0])
-      draw_text(width - 150, 4, status, 0xFF008800);
+      draw_text(width - 95, 4, status, 0xFF008800);
 
     // Separator
     ipc->fill_rect(0, 24, width, 1, 0xFF888888);
@@ -488,37 +525,89 @@ public:
       return;
     }
 
-    if (active_menu == MENU_FILE && x >= 10 && x <= 126) {
-      int item = (y - 24) / 20;
-      if (item == 0) { // New
-        buffer.clear();
-        current_path[0] = 0;
-        my_strcpy(status, "New Doc Created");
-        active_menu = MENU_NONE;
-      } else if (item == 1) {                       // Open
-        buffer.load_file("/home/user/Welcome.txt"); // Test open
-        my_strcpy(current_path, "/home/user/Welcome.txt");
-        my_strcpy(status, "File Opened");
-        active_menu = MENU_NONE;
-      } else if (item == 2) { // Save
-        if (!current_path[0])
-          my_strcpy(current_path, "draft.txt");
-        buffer.save_file(current_path);
-        my_strcpy(status, "Saved!");
-        active_menu = MENU_NONE;
-      } else if (item == 3) {
-        OS::Syscall::exit(0);
+    if (active_menu == MENU_FILE) {
+      // Match exact drawn menu geometry: x=[10..126], y=[26..106)
+      if (x >= 10 && x <= 126 && y >= 26 && y < 106) {
+        int item = (y - 26) / 20;
+        if (item == 0) { // New
+          buffer.clear();
+          my_strcpy(current_path, DEFAULT_NOTE_PATH);
+          my_strcpy(status, "New Doc Created");
+          active_menu = MENU_NONE;
+          render();
+          return;
+        } else if (item == 1) { // Open
+          if (!current_path[0])
+            my_strcpy(current_path, DEFAULT_NOTE_PATH);
+          open_path(current_path);
+          active_menu = MENU_NONE;
+          render();
+          return;
+        } else if (item == 2) { // Save
+          if (!current_path[0])
+            my_strcpy(current_path, DEFAULT_NOTE_PATH);
+          if (buffer.save_file(current_path))
+            my_strcpy(status, "Saved!");
+          else
+            my_strcpy(status, "Save Failed");
+          active_menu = MENU_NONE;
+          render();
+          return;
+        } else if (item == 3) { // Exit
+          active_menu = MENU_NONE;
+          render();
+          if (buffer.dirty) {
+            if (!current_path[0])
+              my_strcpy(current_path, DEFAULT_NOTE_PATH);
+            buffer.save_file(current_path);
+          }
+          ipc->close_window(); // same encoding as red X button
+          OS::Syscall::exit(0);
+          return;
+        }
       }
+
+      // Clicked while File menu is open but not on a valid item -> close menu
+      active_menu = MENU_NONE;
       render();
-    } else if (active_menu == MENU_EDIT && x >= 60 && x <= 176) {
-      if ((y - 24) / 20 == 0) {
+      return;
+    } else if (active_menu == MENU_EDIT) {
+      // Match exact drawn edit menu geometry: x=[60..176], y=[26..46)
+      if (x >= 60 && x <= 176 && y >= 26 && y < 46) {
         buffer.clear();
         my_strcpy(status, "Cleared");
       }
       active_menu = MENU_NONE;
       render();
+      return;
     } else {
       active_menu = MENU_NONE;
+
+      // Click in editor area -> move cursor to clicked text position
+      int start_y = 30;
+      if (y >= start_y && buffer.line_count > 0) {
+        int row_in_view = (y - start_y) / FONT_H;
+        if (row_in_view < 0)
+          row_in_view = 0;
+
+        int target_row = buffer.scroll_y + row_in_view;
+        if (target_row < 0)
+          target_row = 0;
+        if (target_row >= buffer.line_count)
+          target_row = buffer.line_count - 1;
+
+        int target_col = (x - 4) / FONT_W;
+        if (target_col < 0)
+          target_col = 0;
+
+        int line_len = my_strlen(buffer.lines[target_row]);
+        if (target_col > line_len)
+          target_col = line_len;
+
+        buffer.cursor_row = target_row;
+        buffer.cursor_col = target_col;
+      }
+
       render();
     }
   }
@@ -531,17 +620,60 @@ public:
         if (msg.type == OS::MSG_GFX_KEY_EVENT) {
           char k = msg.data.key.key;
           my_strcpy(status, ""); // Clear status on type
-          if (k == '\b')
-            buffer.backspace();
+          bool edited = false;
+
+          // Arrow keys from keyboard driver mapping:
+          // 17=Up, 18=Down, 19=Left, 20=Right
+          if (k == 19) {
+            if (buffer.cursor_col > 0) {
+              buffer.cursor_col--;
+            } else if (buffer.cursor_row > 0) {
+              buffer.cursor_row--;
+              buffer.cursor_col = my_strlen(buffer.lines[buffer.cursor_row]);
+            }
+          } else if (k == 20) {
+            int len = my_strlen(buffer.lines[buffer.cursor_row]);
+            if (buffer.cursor_col < len) {
+              buffer.cursor_col++;
+            } else if (buffer.cursor_row + 1 < buffer.line_count) {
+              buffer.cursor_row++;
+              buffer.cursor_col = 0;
+            }
+          } else if (k == 17) {
+            if (buffer.cursor_row > 0)
+              buffer.cursor_row--;
+            int len = my_strlen(buffer.lines[buffer.cursor_row]);
+            if (buffer.cursor_col > len)
+              buffer.cursor_col = len;
+          } else if (k == 18) {
+            if (buffer.cursor_row + 1 < buffer.line_count)
+              buffer.cursor_row++;
+            int len = my_strlen(buffer.lines[buffer.cursor_row]);
+            if (buffer.cursor_col > len)
+              buffer.cursor_col = len;
+          } else if (k == '\b')
+            buffer.backspace(), edited = true;
           else if (k == '\n' || k == '\r')
-            buffer.newline();
-          else if (k == 19) { // Ctrl-S
+            buffer.newline(), edited = true;
+          else if (k == 14) { // F4 quick-save
             if (!current_path[0])
-              my_strcpy(current_path, "draft.txt");
-            buffer.save_file(current_path);
-            my_strcpy(status, "Saved!");
+              my_strcpy(current_path, DEFAULT_NOTE_PATH);
+            if (buffer.save_file(current_path))
+              my_strcpy(status, "Saved!");
+            else
+              my_strcpy(status, "Save Failed");
           } else if (k >= 32 && k <= 126)
-            buffer.insert_char(k);
+            buffer.insert_char(k), edited = true;
+
+          // Autosave after edits to avoid data loss on close/crash.
+          if (edited) {
+            if (!current_path[0])
+              my_strcpy(current_path, DEFAULT_NOTE_PATH);
+            if (buffer.save_file(current_path))
+              my_strcpy(status, "Saved!");
+            else
+              my_strcpy(status, "Save Failed");
+          }
           render();
         } else if (msg.type == OS::MSG_GFX_MOUSE_EVENT) {
           handle_click(msg.data.mouse.x, msg.data.mouse.y);
@@ -551,10 +683,13 @@ public:
   }
 };
 
-extern "C" void _start() {
+extern "C" void _start(int argc, char **argv) {
   init_font8x8();
   NotepadApp app;
   if (app.init()) {
+    if (argc > 1 && argv && argv[1]) {
+      app.open_path(argv[1]);
+    }
     app.run();
   }
   OS::Syscall::exit(0);

--- a/src/kernel/gui_system.cpp
+++ b/src/kernel/gui_system.cpp
@@ -80,6 +80,7 @@ extern "C" void explorer_open_item(int index);
 extern "C" void explorer_double_click(int index);
 extern "C" void explorer_create_folder(const char *name);
 extern "C" void explorer_context_action(int index, int act);
+extern "C" const char *explorer_get_cwd();
 }
 
 struct Rect {
@@ -620,7 +621,12 @@ void show_context_menu(int x, int y, ContextTarget target, const char *path,
     add_context_item("Undo", ACT_UNDO);
     add_context_item("Redo", ACT_REDO);
     add_context_item("New Folder", ACT_NEW_FOLDER);
+    add_context_item("New Text File", ACT_NEW_FILE);
     add_context_item("Open Terminal", ACT_OPEN_TERMINAL);
+  } else if (target == TARGET_EMPTY) {
+    add_context_item("New Folder", ACT_NEW_FOLDER);
+    add_context_item("New Text File", ACT_NEW_FILE);
+    add_context_item("Refresh", ACT_REFRESH);
   } else {
     add_context_item("Open", ACT_OPEN);
     add_context_item("Select", ACT_SELECT);
@@ -705,6 +711,8 @@ void context_click(int index) {
       serial_log(intent.path);
       sys_context_execute(&intent);
       DesktopSystem::refresh();
+      // Also reload file explorer if it's browsing the affected directory
+      explorer_load_directory(explorer_get_cwd());
     }
   }
   g_ctx_menu.visible = false;
@@ -1262,7 +1270,15 @@ void handle_desktop_input() {
               explorer_load_directory(full);
               launch_explorer();
             } else {
-              sys_spawn(full, nullptr);
+              int len = strlen(full);
+              if (len > 4 &&
+                  (strcmp(full + len - 4, ".txt") == 0 ||
+                   strcmp(full + len - 4, ".TXT") == 0)) {
+                char *argv[] = {(char *)"NOTEPAD.ELF", full, nullptr};
+                sys_spawn("NOTEPAD.ELF", argv);
+              } else {
+                sys_spawn(full, nullptr);
+              }
             }
           }
           dragging_icon_index = -1;
@@ -1767,7 +1783,15 @@ void open_item(const char *path) {
   if (sys_is_dir(path)) {
     explorer_load_directory(path);
   } else {
-    sys_spawn(path, nullptr);
+    int len = strlen(path);
+    if (len > 4 &&
+        (strcmp(path + len - 4, ".txt") == 0 ||
+         strcmp(path + len - 4, ".TXT") == 0)) {
+      char *argv[] = {(char *)"NOTEPAD.ELF", (char *)path, nullptr};
+      sys_spawn("NOTEPAD.ELF", argv);
+    } else {
+      sys_spawn(path, nullptr);
+    }
   }
 }
 
@@ -2017,6 +2041,7 @@ void on_right_click(int x, int y) {
       const char *path = "/";
 
       if (w->draw == (DrawFn)explorer_draw) {
+        path = explorer_get_cwd(); // default to current directory
         int idx = explorer_hit_test(w, x, y);
         if (idx >= 0 && idx < item_count) {
           target = (items[idx].type == 2) ? TARGET_FOLDER : TARGET_FILE;
@@ -3093,6 +3118,7 @@ struct msg_gfx_mouse_event_t {
 struct msg_gfx_key_event_t {
   int window_id;
   char key;
+  int scancode;
 };
 
 struct gfx_msg_t {
@@ -3113,6 +3139,7 @@ void ipc_window_key_callback(Window *w, int key, int scancode) {
     msg.type = 5; // MSG_GFX_KEY_EVENT
     msg.data.key.window_id = w->id;
     msg.data.key.key = (char)key;
+    msg.data.key.scancode = scancode;
     k_write(w->client_fd, &msg, sizeof(msg));
   }
 }
@@ -3178,23 +3205,26 @@ void handle_client_setup(int fd) {
   }
 }
 
-void handle_client_msg(int fd) {
+int handle_client_msg(int fd) {
   gfx_msg_t msg;
   int n = k_read(fd, &msg, sizeof(gfx_msg_t));
   if (n > 0) {
     if (msg.type == 3) { // MSG_GFX_INVALIDATE_RECT
-      // Update the window!
-      // We need to find the window.
-      // Since we don't have a map, let's search windows
       int wid = msg.data.invalidate.window_id;
-      // Iterate all windows
       for (int d = 0; d < 1; d++) {
         for (int i = 0; i < win_count[d]; i++) {
           if (windows[d][i].alive && windows[d][i].id == wid) {
-            // Refresh it!
-            // Since it has backbuffer, next draw_window loop will pick it up.
-            // But checking "dirty" flags might be optimized later.
-            // For now, just ensuring we read the msg clears the pipe.
+            break;
+          }
+        }
+      }
+    } else if (msg.type == 6) { // MSG_GFX_CLOSE_WINDOW — same as red X button
+      for (int d = 0; d < MAX_DESKTOPS; d++) {
+        for (int i = 0; i < win_count[d]; i++) {
+          if (windows[d][i].alive && windows[d][i].client_fd == fd) {
+            windows[d][i].fade.target = 0.0f;
+            windows[d][i].alive = false;
+            serial_log("WS: Close window via Exit menu (MSG_GFX_CLOSE_WINDOW)");
             break;
           }
         }
@@ -3202,6 +3232,7 @@ void handle_client_msg(int fd) {
     }
     // Handle other messages if needed
   }
+  return n;
 }
 
 void init() {
@@ -3259,7 +3290,21 @@ void poll() {
     int fd = client_fds[i];
     if (fd != -1) {
       if (socket_can_read(fd)) {
-        handle_client_msg(fd);
+        int n = handle_client_msg(fd);
+        if (n <= 0) {
+          // Client disconnected — kill its window and free the slot
+          for (int d = 0; d < MAX_DESKTOPS; d++) {
+            for (int j = 0; j < win_count[d]; j++) {
+              if (windows[d][j].alive && windows[d][j].client_fd == fd) {
+                windows[d][j].alive = false;
+              }
+            }
+          }
+          sys_close(fd);
+          client_fds[i] = -1;
+          client_count--;
+          serial_log("WS: Client disconnected, window closed.");
+        }
       }
     }
   }


### PR DESCRIPTION
### Summary
This PR stabilizes Notepad UX and close/open behavior across app and window-server paths.

### Changes
- Make File -> Exit behave like the red titlebar close button by sending a window-close IPC message before process exit.
- Fix File menu hit-testing and outside-click dismissal.
- Improve Notepad open/save behavior with default path handling and clearer status feedback.
- Ensure text saves persist through the Retro-OS disk image flow (FAT16/TRUTH sync), so edits remain after reboot when os.img is reused.
- Route .txt open actions to NOTEPAD.ELF instead of attempting ELF execution.
- Handle disconnected window-server clients cleanly to prevent stuck UI state.
- Update app exit syscall wrapper to prefer POSIX _exit with legacy fallback.

### Result
- Notepad closes correctly from both red close button and File -> Exit.
- No input lock after Exit.
- .txt files open reliably in Notepad.
- Saved notes persist across runs/reboots via os.img persistence path.
- Menu interactions are consistent and non-sticky.