### PR TITLE
feat:

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 <div align="center">
 
-# 👾 Retro Pixel OS  
+# 👾 Retro Pixel OS
 ### *A Hobby Operating System with a Pixel-Art Soul*
 
 ![Retro Pixel OS](https://img.shields.io/badge/OS-Retro%20Pixel-blueviolet?style=for-the-badge)
-![Version](https://img.shields.io/badge/version-0.0.0.0-orange?style=for-the-badge)
+![Version](https://img.shields.io/badge/version-0.1.0-orange?style=for-the-badge)
 ![Architecture](https://img.shields.io/badge/arch-x86-lightgrey?style=for-the-badge)
 ![License](https://img.shields.io/badge/license-MIT-green?style=for-the-badge)
 ![Made With](https://img.shields.io/badge/made%20with-C%20%7C%20ASM%20%7C%20C++-red?style=for-the-badge)
 
-🚀 **A retro-inspired operating system built from scratch**  
-🖥️ **Pixel UI • Custom Kernel • Terminal • File Tools**  
+🚀 **A retro-inspired operating system built from scratch**
+🖥️ **Pixel UI • Custom Kernel • HTTPS Support • Terminal • Apps**
 🧠 **Perfect for OS dev learners & low-level hackers**
 
 </div>
@@ -20,113 +20,122 @@
 ## 🧠 What is Retro Pixel OS?
 
 **Retro Pixel OS** is a **from-scratch hobby operating system** designed to:
-- Teach **low-level OS development**
-- Recreate the **feel of early computing**
-- Combine **pixel-art UI** with a **functional terminal**
-- Run inside an emulator (QEMU)
+- Teach **low-level OS development** (bare-metal)
+- Recreate the **feel of early computing** with a modern twist
+- Provide a **Pixel-art GUI** environment
+- Support **HTTPS communication** via integrated mbedTLS
+- Run inside the **QEMU** emulator
 
 ---
-⚠️ *Not meant for production use. This is a learning OS. But Who knows the Future...*
----
-⚠️*This is not a linux Distro and I haven't used any C++ or C library, every Library for RetroPixelOS is solely writtern and hard-coded*
+⚠️ **Educational Project**: This is a learning OS. It is NOT a Linux distribution. No standard C/C++ libraries are used; every component, from the memory manager to the network stack, is custom-built or manually integrated for the bare-metal environment.
 ---
 
-## ✨ Features
+## ✨ Key Features
 
-- Custom bootloader (writtern in Assembly)
-- Kernel (written in C/C++)
-- Pixel-based graphical interface
-- Built-in terminal
-- File manager (`fm`)
-- Calculator (`calc`)
-- Disk info (`df`)
-- Runs on QEMU (x86)
+- **Custom Bootloader**: Hand-rolled x86 assembly.
+- **Micro-Kernel**: Multi-tasking, memory management, and interrupt handling.
+- **Pixel GUI**: A vibrant, retro-styled graphical user interface.
+- **HTTPS Stack**: Native HTTPS support via mbedTLS glue logic.
+- **App Suite**: Terminal (`sh`), Notepad, File Manager, Calculator, Ping, and more.
+- **Custom Libs**: Proprietary implementation of core C/C++ headers and functions.
 
 ---
 
-## 🧰 Tech Stack
+## 🛠 Prerequisites (Windows / Linux)
 
-| Layer | Technology |
-|-----|-----------|
-| Bootloader | NASM |
-| Kernel | C / C++ |
-| Emulator | QEMU |
-| Build Tools | GCC |
-| Platform | Windows (WSL) |
+To build and run Retro Pixel OS, you need a Unix-like environment. On Windows, we recommend **WSL (Ubuntu)**.
+
+### 1. Development Tools
+| Tool | Purpose |
+|------|---------|
+| **GCC/G++** | C/C++ Compiler (32-bit multilib) |
+| **NASM** | Assembly Compiler |
+| **Make** | Build automation |
+| **QEMU** | x86 System Emulator |
+| **Python 3** | Scripting for asset injection |
+| **Git** | Version Control |
 
 ---
 
-## 🚀 Getting Started
+## 🚀 Installation & Setup
 
-### Step 1: Install WSL
+Follow these steps exactly to get the OS running on your machine.
+
+### Step 1: Prepare the Environment (WSL Users)
+If you are on Windows, open PowerShell as Administrator and run:
 ```powershell
 wsl --install
 ```
-
-Restart your system and open **Ubuntu**.
-
----
+*Restart your computer if prompted.* Then open your **Ubuntu** terminal.
 
 ### Step 2: Install Dependencies
+Copy and paste this command into your terminal:
 ```bash
-sudo apt update && sudo apt install build-essential g++-multilib nasm qemu-system-x86 mtools python3 git -y
+sudo apt update && sudo apt install -y build-essential g++-multilib nasm qemu-system-x86 mtools dosfstools python3 git
 ```
 
----
-
-### Step 3: Clone Repository
+### Step 3: Clone the Repository
 ```bash
-git clone https://github.com/Mr-charvaka/Operating-System--Version-0.0.0.0.git
-cd Operating-System--Version-0.0.0.0
+git clone https://github.com/Mr-Charvaka/Retro-Os.git
+cd Retro-Os
 ```
 
----
-
-### Step 4: Build
+### Step 4: Build the OS Image
+The build script compiles the bootloader, kernel, and apps, then bundles them into `os.img`.
+It also auto-creates `data.img` (128MB, FAT16) if missing for persistent user data.
 ```bash
+# Make the script executable
 chmod +x build.sh
+
+# Run the build
 ./build.sh
 ```
+*You should see a "Build Successful: os.img" message.*
 
----
+### Step 5: Launch the OS
 
-### Step 5: Run
+#### Option A: Standard Run (No Network)
 ```bash
-qemu-system-i386 -drive format=raw,file=os.img -serial stdio -m 512
+qemu-system-i386 -drive format=raw,file=os.img -drive format=raw,file=data.img,if=ide,index=1 -serial stdio -m 512
 ```
 
-**Demo:**
-
---- 
-<img width="1024" height="831" alt="1" src="https://github.com/user-attachments/assets/994d1538-4e37-4eea-9990-35019c292daf" />
-<img width="1026" height="771" alt="2" src="https://github.com/user-attachments/assets/247b74df-2a6f-49d3-bdc7-69cdffff7708" />
-<img width="1024" height="770" alt="3" src="https://github.com/user-attachments/assets/bdb7a9a6-3dd3-4cfa-a4bd-8f26ff2805a7" />
-
----
-## 🎮 Terminal Commands
-
+#### Option B: Run with Internet Access (Recommended)
+This enables the E1000 network driver and allows the OS to use DNS, DHCP, and HTTPS.
 ```bash
-ls
-calc 5 + 5
-df
-fm
+qemu-system-i386 -drive format=raw,file=os.img -drive format=raw,file=data.img,if=ide,index=1 -serial stdio -m 512 -net nic,model=e1000 -net user
 ```
 
 ---
 
-## 🛣 Roadmap
+## 🎮 Inside the OS
 
-- Keyboard driver
-- Memory management
-- Scheduler
-- GUI improvements
-- Filesystem support
+Once the GUI loads, you can use the following terminal commands:
+
+| Command | Description |
+|---------|-------------|
+| `ls` | List files in the current directory |
+| `sh` | Open the shell |
+| `calc 5 + 5` | Use the built-in calculator |
+| `ping [ip]` | Test network connectivity |
+| `notepad` | Basic text editing |
+| `df` | View disk frequency/info |
+| `init` | Restart system services |
 
 ---
 
-## 📜 License
+## 📂 Project Structure
 
-MIT License
+- `/src/boot`: Bootloader and Kernel entry code (ASM).
+- `/src/kernel`: Core kernel logic (Memory, Tasks, Interrupts, Networking).
+- `/src/include`: Custom system headers and mbedTLS configurations.
+- `/apps`: Source code for user-mode applications.
+- `/assets`: Wallpapers and UI resources.
+
+---
+
+## 📜 License & Credits
+
+Distributed under the **MIT License**. Created with ❤️ by Mr-Charvaka/ Aman.
 
 ---
 

--- a/apps/notepad.cpp
+++ b/apps/notepad.cpp
@@ -150,6 +150,7 @@ void init_font8x8() {
 
 #define FONT_W 9
 #define FONT_H 16
+static const char *DEFAULT_NOTE_PATH = "/home/user/Desktop/note.txt";
 
 // ---------------------------------------------
 // Text Buffer
@@ -242,41 +243,59 @@ struct TextBuffer {
     s = n;
   }
 
-  void load_file(const char *path) {
+  bool load_file(const char *path) {
     int fd = OS::Syscall::open(path, O_RDONLY);
     if (fd < 0)
-      return;
+      return false;
 
     clear();
     char *buf = new char[32768];
     int n = OS::Syscall::read(fd, buf, 32768);
     OS::Syscall::close(fd);
 
+    if (n < 0) {
+      delete[] buf;
+      return false;
+    }
+
     if (n > 0) {
       for (int i = 0; i < n; i++) {
         if (buf[i] == '\n') {
           add_line("");
-        } else if (buf[i] != '\r') {
+        } else if (buf[i] == '\r') {
+          // ignore
+        } else if ((buf[i] >= 32 && buf[i] <= 126) || buf[i] == '\t') {
           append_char(lines[line_count - 1], buf[i]);
         }
       }
     }
     delete[] buf;
     dirty = false;
+    return true;
   }
 
-  void save_file(const char *path) {
+  bool save_file(const char *path) {
     int fd = OS::Syscall::open(path, O_CREAT | O_WRONLY | O_TRUNC);
     if (fd < 0)
-      return;
+      return false;
 
     for (int i = 0; i < line_count; i++) {
-      OS::Syscall::write(fd, lines[i], my_strlen(lines[i]));
-      if (i < line_count - 1)
-        OS::Syscall::write(fd, "\n", 1);
+      int len = my_strlen(lines[i]);
+      int w = OS::Syscall::write(fd, lines[i], len);
+      if (w != len) {
+        OS::Syscall::close(fd);
+        return false;
+      }
+      if (i < line_count - 1) {
+        if (OS::Syscall::write(fd, "\n", 1) != 1) {
+          OS::Syscall::close(fd);
+          return false;
+        }
+      }
     }
     OS::Syscall::close(fd);
     dirty = false;
+    return true;
   }
 
   char *concat(const char *s1, const char *s2) {
@@ -370,7 +389,7 @@ class NotepadApp {
 public:
   NotepadApp() : ipc(nullptr), width(600), height(400), active_menu(MENU_NONE) {
     my_strcpy(title, "Notepad");
-    current_path[0] = 0;
+    my_strcpy(current_path, DEFAULT_NOTE_PATH);
     status[0] = 0;
   }
   ~NotepadApp() {
@@ -385,6 +404,24 @@ public:
     if (!ipc->create_window(title, width, height))
       return false;
     return true;
+  }
+
+  bool open_path(const char *path) {
+    if (!path || !path[0])
+      return false;
+    my_strcpy(current_path, path);
+    if (buffer.load_file(path)) {
+      // Place cursor at end of loaded content for immediate editing
+      buffer.cursor_row = buffer.line_count - 1;
+      if (buffer.cursor_row < 0)
+        buffer.cursor_row = 0;
+      buffer.cursor_col = my_strlen(buffer.lines[buffer.cursor_row]);
+      my_strcpy(status, "File Opened");
+      return true;
+    }
+    buffer.clear();
+    my_strcpy(status, "New File");
+    return false;
   }
 
   void draw_text(int x, int y, const char *txt, uint32_t color) {
@@ -423,7 +460,7 @@ public:
     if (current_path[0])
       draw_text(200, 4, current_path, 0xFF666666);
     if (status[0])
-      draw_text(width - 150, 4, status, 0xFF008800);
+      draw_text(width - 95, 4, status, 0xFF008800);
 
     // Separator
     ipc->fill_rect(0, 24, width, 1, 0xFF888888);
@@ -488,37 +525,89 @@ public:
       return;
     }
 
-    if (active_menu == MENU_FILE && x >= 10 && x <= 126) {
-      int item = (y - 24) / 20;
-      if (item == 0) { // New
-        buffer.clear();
-        current_path[0] = 0;
-        my_strcpy(status, "New Doc Created");
-        active_menu = MENU_NONE;
-      } else if (item == 1) {                       // Open
-        buffer.load_file("/home/user/Welcome.txt"); // Test open
-        my_strcpy(current_path, "/home/user/Welcome.txt");
-        my_strcpy(status, "File Opened");
-        active_menu = MENU_NONE;
-      } else if (item == 2) { // Save
-        if (!current_path[0])
-          my_strcpy(current_path, "draft.txt");
-        buffer.save_file(current_path);
-        my_strcpy(status, "Saved!");
-        active_menu = MENU_NONE;
-      } else if (item == 3) {
-        OS::Syscall::exit(0);
+    if (active_menu == MENU_FILE) {
+      // Match exact drawn menu geometry: x=[10..126], y=[26..106)
+      if (x >= 10 && x <= 126 && y >= 26 && y < 106) {
+        int item = (y - 26) / 20;
+        if (item == 0) { // New
+          buffer.clear();
+          my_strcpy(current_path, DEFAULT_NOTE_PATH);
+          my_strcpy(status, "New Doc Created");
+          active_menu = MENU_NONE;
+          render();
+          return;
+        } else if (item == 1) { // Open
+          if (!current_path[0])
+            my_strcpy(current_path, DEFAULT_NOTE_PATH);
+          open_path(current_path);
+          active_menu = MENU_NONE;
+          render();
+          return;
+        } else if (item == 2) { // Save
+          if (!current_path[0])
+            my_strcpy(current_path, DEFAULT_NOTE_PATH);
+          if (buffer.save_file(current_path))
+            my_strcpy(status, "Saved!");
+          else
+            my_strcpy(status, "Save Failed");
+          active_menu = MENU_NONE;
+          render();
+          return;
+        } else if (item == 3) { // Exit
+          active_menu = MENU_NONE;
+          render();
+          if (buffer.dirty) {
+            if (!current_path[0])
+              my_strcpy(current_path, DEFAULT_NOTE_PATH);
+            buffer.save_file(current_path);
+          }
+          ipc->close_window(); // same encoding as red X button
+          OS::Syscall::exit(0);
+          return;
+        }
       }
+
+      // Clicked while File menu is open but not on a valid item -> close menu
+      active_menu = MENU_NONE;
       render();
-    } else if (active_menu == MENU_EDIT && x >= 60 && x <= 176) {
-      if ((y - 24) / 20 == 0) {
+      return;
+    } else if (active_menu == MENU_EDIT) {
+      // Match exact drawn edit menu geometry: x=[60..176], y=[26..46)
+      if (x >= 60 && x <= 176 && y >= 26 && y < 46) {
         buffer.clear();
         my_strcpy(status, "Cleared");
       }
       active_menu = MENU_NONE;
       render();
+      return;
     } else {
       active_menu = MENU_NONE;
+
+      // Click in editor area -> move cursor to clicked text position
+      int start_y = 30;
+      if (y >= start_y && buffer.line_count > 0) {
+        int row_in_view = (y - start_y) / FONT_H;
+        if (row_in_view < 0)
+          row_in_view = 0;
+
+        int target_row = buffer.scroll_y + row_in_view;
+        if (target_row < 0)
+          target_row = 0;
+        if (target_row >= buffer.line_count)
+          target_row = buffer.line_count - 1;
+
+        int target_col = (x - 4) / FONT_W;
+        if (target_col < 0)
+          target_col = 0;
+
+        int line_len = my_strlen(buffer.lines[target_row]);
+        if (target_col > line_len)
+          target_col = line_len;
+
+        buffer.cursor_row = target_row;
+        buffer.cursor_col = target_col;
+      }
+
       render();
     }
   }
@@ -531,17 +620,60 @@ public:
         if (msg.type == OS::MSG_GFX_KEY_EVENT) {
           char k = msg.data.key.key;
           my_strcpy(status, ""); // Clear status on type
-          if (k == '\b')
-            buffer.backspace();
+          bool edited = false;
+
+          // Arrow keys from keyboard driver mapping:
+          // 17=Up, 18=Down, 19=Left, 20=Right
+          if (k == 19) {
+            if (buffer.cursor_col > 0) {
+              buffer.cursor_col--;
+            } else if (buffer.cursor_row > 0) {
+              buffer.cursor_row--;
+              buffer.cursor_col = my_strlen(buffer.lines[buffer.cursor_row]);
+            }
+          } else if (k == 20) {
+            int len = my_strlen(buffer.lines[buffer.cursor_row]);
+            if (buffer.cursor_col < len) {
+              buffer.cursor_col++;
+            } else if (buffer.cursor_row + 1 < buffer.line_count) {
+              buffer.cursor_row++;
+              buffer.cursor_col = 0;
+            }
+          } else if (k == 17) {
+            if (buffer.cursor_row > 0)
+              buffer.cursor_row--;
+            int len = my_strlen(buffer.lines[buffer.cursor_row]);
+            if (buffer.cursor_col > len)
+              buffer.cursor_col = len;
+          } else if (k == 18) {
+            if (buffer.cursor_row + 1 < buffer.line_count)
+              buffer.cursor_row++;
+            int len = my_strlen(buffer.lines[buffer.cursor_row]);
+            if (buffer.cursor_col > len)
+              buffer.cursor_col = len;
+          } else if (k == '\b')
+            buffer.backspace(), edited = true;
           else if (k == '\n' || k == '\r')
-            buffer.newline();
-          else if (k == 19) { // Ctrl-S
+            buffer.newline(), edited = true;
+          else if (k == 14) { // F4 quick-save
             if (!current_path[0])
-              my_strcpy(current_path, "draft.txt");
-            buffer.save_file(current_path);
-            my_strcpy(status, "Saved!");
+              my_strcpy(current_path, DEFAULT_NOTE_PATH);
+            if (buffer.save_file(current_path))
+              my_strcpy(status, "Saved!");
+            else
+              my_strcpy(status, "Save Failed");
           } else if (k >= 32 && k <= 126)
-            buffer.insert_char(k);
+            buffer.insert_char(k), edited = true;
+
+          // Autosave after edits to avoid data loss on close/crash.
+          if (edited) {
+            if (!current_path[0])
+              my_strcpy(current_path, DEFAULT_NOTE_PATH);
+            if (buffer.save_file(current_path))
+              my_strcpy(status, "Saved!");
+            else
+              my_strcpy(status, "Save Failed");
+          }
           render();
         } else if (msg.type == OS::MSG_GFX_MOUSE_EVENT) {
           handle_click(msg.data.mouse.x, msg.data.mouse.y);
@@ -551,10 +683,16 @@ public:
   }
 };
 
-extern "C" void _start() {
+extern "C" void _start(int argc, char **argv) {
   init_font8x8();
   NotepadApp app;
   if (app.init()) {
+    if (argc > 1 && argv && argv[1]) {
+      app.open_path(argv[1]);
+    } else {
+      // Launching from app menu should reopen the persistent default note.
+      app.open_path(DEFAULT_NOTE_PATH);
+    }
     app.run();
   }
   OS::Syscall::exit(0);

--- a/build.sh
+++ b/build.sh
@@ -3,10 +3,28 @@ set -e
 
 echo "Building inside WSL..."
 
+DATA_IMG="data.img"
+DATA_IMG_SIZE="128M"
+
 # Clean previous build
 find src -name "*.o" -type f -delete
 find apps -name "*.o" -type f -delete
 rm -f os.img
+
+if [ ! -f "$DATA_IMG" ]; then
+    echo "Creating persistent $DATA_IMG ($DATA_IMG_SIZE)..."
+    truncate -s "$DATA_IMG_SIZE" "$DATA_IMG"
+
+    if command -v mkfs.fat >/dev/null 2>&1; then
+        mkfs.fat -F 16 -n RETRODATA "$DATA_IMG" >/dev/null
+    elif command -v mformat >/dev/null 2>&1; then
+        mformat -i "$DATA_IMG" -F -v RETRODATA ::
+    else
+        echo "Error: mkfs.fat or mformat is required to initialize $DATA_IMG"
+        echo "Install one of: dosfstools or mtools"
+        exit 1
+    fi
+fi
 
 # Compile Apps
 echo "Compiling apps (C++)..."
@@ -96,4 +114,4 @@ truncate -s 32M os.img
 echo "Injecting Files..."
 python3 inject_wallpaper.py
 
-echo "Build Successful: os.img"
+echo "Build Successful: os.img (system) + $DATA_IMG (persistent data)"

--- a/src/drivers/ata.cpp
+++ b/src/drivers/ata.cpp
@@ -1,0 +1,113 @@
+#include "ata.h"
+#include "../include/io.h"
+#include "serial.h"
+
+static uint8_t g_ata_selected_drive = 0;
+
+static void ata_io_delay() {
+  // 400ns delay required after drive/head changes on ATA.
+  inb(ATA_STATUS);
+  inb(ATA_STATUS);
+  inb(ATA_STATUS);
+  inb(ATA_STATUS);
+}
+
+static bool ata_wait_bsy() {
+  for (uint32_t i = 0; i < 100000000; i++) {
+    uint8_t st = inb(ATA_STATUS);
+    if (st == 0x00 || st == 0xFF)
+      return false;
+    if ((st & ATA_SR_BSY) == 0)
+      return true;
+  }
+  return false;
+}
+
+static bool ata_wait_drq() {
+  for (uint32_t i = 0; i < 100000000; i++) {
+    uint8_t st = inb(ATA_STATUS);
+    if (st == 0x00 || st == 0xFF)
+      return false;
+    if (st & ATA_SR_ERR)
+      return false;
+    if (st & ATA_SR_DRQ)
+      return true;
+  }
+  return false;
+}
+
+void ata_set_drive(uint8_t drive) { g_ata_selected_drive = drive ? 1 : 0; }
+
+uint8_t ata_get_drive() { return g_ata_selected_drive; }
+
+void ata_read_sector_drive(uint8_t drive, uint32_t lba, uint8_t *buffer) {
+  asm volatile("cli");
+  if (!ata_wait_bsy()) {
+    for (int i = 0; i < 512; i++)
+      buffer[i] = 0;
+    asm volatile("sti");
+    return;
+  }
+
+  outb(ATA_DRIVE_HEAD,
+       0xE0 | ((drive ? 1 : 0) << 4) | ((lba >> 24) & 0x0F));
+    ata_io_delay();
+  outb(ATA_ERROR, 0x00);                             // Null byte
+  outb(ATA_SECTOR_CNT, 1);                           // Sector Count = 1
+  outb(ATA_LBA_LO, (uint8_t)lba);
+  outb(ATA_LBA_MID, (uint8_t)(lba >> 8));
+  outb(ATA_LBA_HI, (uint8_t)(lba >> 16));
+  outb(ATA_COMMAND, ATA_CMD_READ_PIO);
+
+  if (!ata_wait_bsy() || !ata_wait_drq()) {
+    for (int i = 0; i < 512; i++)
+      buffer[i] = 0;
+    asm volatile("sti");
+    return;
+  }
+
+  // Read 256 words (512 bytes)
+  uint16_t *buf16 = (uint16_t *)buffer;
+  for (int i = 0; i < 256; i++) {
+    buf16[i] = inw(ATA_DATA);
+  }
+  asm volatile("sti");
+}
+
+void ata_write_sector_drive(uint8_t drive, uint32_t lba, uint8_t *buffer) {
+  if (!ata_wait_bsy()) {
+    return;
+  }
+
+  outb(ATA_DRIVE_HEAD,
+       0xE0 | ((drive ? 1 : 0) << 4) | ((lba >> 24) & 0x0F));
+    ata_io_delay();
+  outb(ATA_ERROR, 0x00);
+  outb(ATA_SECTOR_CNT, 1);
+  outb(ATA_LBA_LO, (uint8_t)lba);
+  outb(ATA_LBA_MID, (uint8_t)(lba >> 8));
+  outb(ATA_LBA_HI, (uint8_t)(lba >> 16));
+  outb(ATA_COMMAND, ATA_CMD_WRITE_PIO);
+
+  if (!ata_wait_bsy() || !ata_wait_drq()) {
+    return;
+  }
+
+  // Write 256 words
+  uint16_t *buf16 = (uint16_t *)buffer;
+  for (int i = 0; i < 256; i++) {
+    outw(ATA_DATA, buf16[i]);
+  }
+
+  // Flush Cache
+  outb(ATA_COMMAND, 0xE7);
+  ata_wait_bsy();
+}
+
+void ata_read_sector(uint32_t lba, uint8_t *buffer) {
+  ata_read_sector_drive(g_ata_selected_drive, lba, buffer);
+}
+
+void ata_write_sector(uint32_t lba, uint8_t *buffer) {
+  ata_write_sector_drive(g_ata_selected_drive, lba, buffer);
+}

--- a/src/drivers/ata.h
+++ b/src/drivers/ata.h
@@ -1,0 +1,34 @@
+#ifndef ATA_H
+#define ATA_H
+
+#include "../include/types.h"
+
+// ATA Bus I/O Ports (Primary Bus)
+#define ATA_DATA 0x1F0
+#define ATA_ERROR 0x1F1
+#define ATA_SECTOR_CNT 0x1F2
+#define ATA_LBA_LO 0x1F3
+#define ATA_LBA_MID 0x1F4
+#define ATA_LBA_HI 0x1F5
+#define ATA_DRIVE_HEAD 0x1F6
+#define ATA_STATUS 0x1F7
+#define ATA_COMMAND 0x1F7
+
+// Status Flags
+#define ATA_SR_BSY 0x80 // Busy
+#define ATA_SR_DRQ 0x08 // Data Request ready
+#define ATA_SR_ERR 0x01 // Error
+
+// Commands
+#define ATA_CMD_READ_PIO 0x20
+#define ATA_CMD_WRITE_PIO 0x30
+
+// Functions
+void ata_set_drive(uint8_t drive);
+uint8_t ata_get_drive();
+void ata_read_sector_drive(uint8_t drive, uint32_t lba, uint8_t *buffer);
+void ata_write_sector_drive(uint8_t drive, uint32_t lba, uint8_t *buffer);
+void ata_read_sector(uint32_t lba, uint8_t *buffer);
+void ata_write_sector(uint32_t lba, uint8_t *buffer);
+
+#endif

--- a/src/drivers/fat16.cpp
+++ b/src/drivers/fat16.cpp
@@ -1,0 +1,710 @@
+#include "fat16.h"
+#include "../include/dirent.h"
+#include "../include/string.h"
+#include "../include/vfs.h"
+#include "../kernel/heap.h"
+#include "../kernel/memory.h"
+#include "ata.h"
+#include "serial.h"
+
+// Forward declaration for DevFS
+extern "C" vfs_node_t *devfs_init();
+static vfs_node_t *devfs_node = 0;
+
+extern "C" {
+
+static fat16_bpb_t bpb;
+static uint32_t root_dir_start_sector;
+static uint32_t data_start_sector;
+static uint32_t root_sectors;
+static uint8_t g_fat16_drive = 0;
+
+// Forward Declarations
+static uint32_t fat16_write_vfs(vfs_node_t *node, uint32_t offset,
+                                uint32_t size, uint8_t *buffer);
+static uint32_t fat16_read_vfs(vfs_node_t *node, uint32_t offset, uint32_t size,
+                               uint8_t *buffer);
+
+// ============================================================================
+// Low Level Helpers - Chote mote kaam
+// ============================================================================
+
+static uint32_t fat16_cluster_to_sector(uint16_t cluster) {
+  return data_start_sector + (cluster - 2) * bpb.sectors_per_cluster;
+}
+
+static uint32_t fat16_get_fat_sector() { return bpb.reserved_sectors; }
+
+static uint16_t fat16_get_fat_entry(uint16_t cluster) {
+  uint32_t fat_offset = cluster * 2;
+  uint32_t fat_sector = fat16_get_fat_sector() + (fat_offset / 512);
+  uint32_t entry_offset = fat_offset % 512;
+
+  uint8_t buffer[512];
+  ata_read_sector(fat_sector, buffer);
+  return *(uint16_t *)(buffer + entry_offset);
+}
+
+static void fat16_set_fat_entry(uint16_t cluster, uint16_t value) {
+  uint32_t fat_offset = cluster * 2;
+  uint32_t fat_sector = fat16_get_fat_sector() + (fat_offset / 512);
+  uint32_t entry_offset = fat_offset % 512;
+
+  uint8_t buffer[512];
+  ata_read_sector(fat_sector, buffer);
+  *(uint16_t *)(buffer + entry_offset) = value;
+  ata_write_sector(fat_sector, buffer);
+
+  // Agar backup FAT hai toh wahan bhi likho
+  if (bpb.fats_count > 1) {
+    ata_write_sector(fat_sector + bpb.sectors_per_fat, buffer);
+  }
+}
+
+static uint16_t fat16_alloc_cluster() {
+  for (uint16_t cluster = 2; cluster < 0xFFF0; cluster++) {
+    if (fat16_get_fat_entry(cluster) == 0x0000) {
+      fat16_set_fat_entry(cluster, 0xFFFF); // Mark as EOF (Kaam ho gaya)
+      return cluster;
+    }
+  }
+  return 0; // Disk full
+}
+
+// 8.3 filename ko insaan ke padhne layak banao
+static void fat16_to_name(char *dest, char *src, char *ext) {
+  int k = 0;
+  for (int j = 0; j < 8; j++)
+    if (src[j] != ' ')
+      dest[k++] = src[j];
+
+  if (ext[0] != ' ') {
+    dest[k++] = '.';
+    for (int j = 0; j < 3; j++)
+      if (ext[j] != ' ')
+        dest[k++] = ext[j];
+  }
+  dest[k] = 0;
+}
+
+// ============================================================================
+// Directory Operations
+// ============================================================================
+
+// Iterator callback: 0 return karo aage badhne ke liye, 1 agar mil gaya, -1
+// error
+typedef int (*dir_iterator_t)(fat16_entry_t *entry, uint32_t sector,
+                              uint32_t offset, void *data);
+
+// Generic directory iterator (Root (0) aur Subdirs (cluster) dono ke liye
+// chalta hai)
+static int fat16_iterate_dir(uint16_t dir_cluster, dir_iterator_t callback,
+                             void *data) {
+  uint8_t buffer[512];
+
+  if (dir_cluster == 0) {
+    // Root Directory Iteration
+    // serial_log_hex("FAT16: Iterating ROOT dir at sector ",
+    //                root_dir_start_sector); // Removed for optimization
+    for (uint32_t s = 0; s < root_sectors; s++) {
+      ata_read_sector(root_dir_start_sector + s, buffer);
+      fat16_entry_t *entries = (fat16_entry_t *)buffer;
+      for (int i = 0; i < 16; i++) {
+        if (entries[i].filename[0] != 0 &&
+            (uint8_t)entries[i].filename[0] != 0xE5) {
+          // serial_log("FAT16: Valid Entry found in sector...");
+        }
+        int res = callback(&entries[i], root_dir_start_sector + s,
+                           i * sizeof(fat16_entry_t), data);
+        if (res != 0)
+          return res;
+      }
+    }
+  } else {
+    // Subdirectory Iteration (Cluster Chain)
+    uint16_t cluster = dir_cluster;
+    while (cluster >= 2 && cluster < 0xFFF0) {
+      uint32_t start_sector = fat16_cluster_to_sector(cluster);
+      for (int s = 0; s < bpb.sectors_per_cluster; s++) {
+        ata_read_sector(start_sector + s, buffer);
+        fat16_entry_t *entries = (fat16_entry_t *)buffer;
+        for (int i = 0; i < 16; i++) {
+          int res = callback(&entries[i], start_sector + s,
+                             i * sizeof(fat16_entry_t), data);
+          if (res != 0)
+            return res;
+        }
+      }
+      cluster = fat16_get_fat_entry(cluster);
+    }
+  }
+  return 0;
+}
+
+struct find_ctx {
+  const char *name;
+  fat16_entry_t result;
+  bool found;
+  uint32_t sector; // Location of found entry
+  uint32_t offset;
+};
+
+static int find_callback(fat16_entry_t *entry, uint32_t sector, uint32_t offset,
+                         void *d_ptr) {
+  find_ctx *ctx = (find_ctx *)d_ptr;
+
+  if (entry->filename[0] == 0)
+    return 1; // Directory khatam
+  if ((uint8_t)entry->filename[0] == 0xE5)
+    return 0; // Deleted hai ye
+  if (entry->attributes == ATTR_LFN)
+    return 0; // Skip LFN
+
+  char name[13];
+  fat16_to_name(name, entry->filename, entry->ext);
+
+  /*serial_log("FAT16 Check: '");
+  serial_log(name);
+  serial_log("' vs '");
+  serial_log(ctx->name);
+  serial_log("'\n");*/
+
+  // Case-insensitive comparison
+  bool match = true;
+  for (int i = 0;; i++) {
+    char c1 = name[i];
+    char c2 = ctx->name[i];
+    if (c1 >= 'a' && c1 <= 'z')
+      c1 -= 32;
+    if (c2 >= 'a' && c2 <= 'z')
+      c2 -= 32;
+    if (c1 != c2) {
+      match = false;
+      break;
+    }
+    if (c1 == 0)
+      break;
+  }
+
+  if (match) {
+    ctx->result = *entry;
+    ctx->found = true;
+    ctx->sector = sector;
+    ctx->offset = offset;
+    return 1; // Stop
+  }
+  return 0;
+}
+
+static bool fat16_find_entry(uint16_t dir_cluster, const char *name,
+                             fat16_entry_t *out) {
+  find_ctx ctx;
+  ctx.name = name;
+  ctx.found = false;
+  fat16_iterate_dir(dir_cluster, find_callback, &ctx);
+  if (ctx.found && out)
+    *out = ctx.result;
+  return ctx.found;
+}
+
+struct create_ctx {
+  uint32_t free_sector;
+  uint32_t free_offset;
+  bool slot_found;
+};
+
+static int find_free_callback(fat16_entry_t *entry, uint32_t sector,
+                              uint32_t offset, void *d_ptr) {
+  create_ctx *ctx = (create_ctx *)d_ptr;
+  if (entry->filename[0] == 0 || (uint8_t)entry->filename[0] == 0xE5) {
+    ctx->free_sector = sector;
+    ctx->free_offset = offset;
+    ctx->slot_found = true;
+    return 1; // Found slot
+  }
+  return 0;
+}
+
+static int fat16_add_entry(uint16_t dir_cluster, const char *name, uint8_t attr,
+                           uint16_t cluster) {
+  // Check existence
+  if (fat16_find_entry(dir_cluster, name, 0))
+    return -1; // Exists
+
+  create_ctx ctx;
+  ctx.slot_found = false;
+  fat16_iterate_dir(dir_cluster, find_free_callback, &ctx);
+
+  if (!ctx.slot_found) {
+    // TODO: Directory ko badhana padega agar root nahi hai
+    return -2; // Jagah nahi hai
+  }
+
+  // Parse Name
+  fat16_entry_t entry;
+  memset(&entry, 0, sizeof(fat16_entry_t));
+  memset(entry.filename, ' ', 8);
+  memset(entry.ext, ' ', 3);
+
+  int fi = 0, in_ext = 0, ei = 0;
+  for (int i = 0; name[i]; i++) {
+    char ch = name[i];
+    if (ch >= 'a' && ch <= 'z')
+      ch -= 32;
+
+    if (ch == '.') {
+      in_ext = 1;
+      ei = 0;
+      continue;
+    }
+    if (in_ext) {
+      if (ei < 3)
+        entry.ext[ei++] = ch;
+    } else {
+      if (fi < 8)
+        entry.filename[fi++] = ch;
+    }
+  }
+
+  entry.attributes = attr;
+  entry.first_cluster_low = cluster;
+  entry.file_size = 0; // 0 for now
+
+  // Write Entry
+  uint8_t buffer[512];
+  ata_read_sector(ctx.free_sector, buffer);
+  memcpy(buffer + ctx.free_offset, &entry, sizeof(fat16_entry_t));
+  ata_write_sector(ctx.free_sector, buffer);
+
+  return 0;
+}
+
+void fat16_get_stats_bytes(uint32_t *total_bytes, uint32_t *free_bytes) {
+  uint32_t total_sectors =
+      bpb.total_sectors_16 != 0 ? bpb.total_sectors_16 : bpb.total_sectors_32;
+  if (total_bytes)
+    *total_bytes = total_sectors * 512;
+  if (free_bytes) {
+    // Return a reasonable placeholder or count clusters
+    // For 32MB image, let's say 25MB is free
+    *free_bytes = 25 * 1024 * 1024;
+  }
+}
+
+// ============================================================================
+// Public API Impl
+// ============================================================================
+
+void fat16_set_drive(uint8_t drive) {
+  g_fat16_drive = drive ? 1 : 0;
+  ata_set_drive(g_fat16_drive);
+}
+
+uint8_t fat16_get_drive() { return g_fat16_drive; }
+
+void fat16_init() {
+  ata_set_drive(g_fat16_drive);
+  uint8_t sector[512];
+  ata_read_sector(0, sector);
+  memcpy(&bpb, sector, sizeof(fat16_bpb_t));
+
+  root_dir_start_sector =
+      bpb.reserved_sectors + (bpb.fats_count * bpb.sectors_per_fat);
+  root_sectors = (bpb.root_entries_count * 32 + 511) / 512;
+  data_start_sector = root_dir_start_sector + root_sectors;
+
+  serial_log("FAT16: Subdir support ke saath initialize ho gaya.");
+}
+
+fat16_entry_t fat16_find_file(const char *filename) {
+  fat16_entry_t out;
+  if (fat16_find_entry(0, filename, &out))
+    return out;
+  memset(&out, 0, sizeof(out));
+  return out;
+}
+
+void fat16_read_file(fat16_entry_t *entry, uint8_t *buffer) {
+  uint16_t cluster = entry->first_cluster_low;
+  uint32_t size = entry->file_size;
+  uint32_t bytes_read = 0;
+
+  while (cluster >= 2 && cluster < 0xFFF0 && bytes_read < size) {
+    uint32_t sector = fat16_cluster_to_sector(cluster);
+    for (int i = 0; i < bpb.sectors_per_cluster; i++) {
+      ata_read_sector(sector + i, buffer + bytes_read);
+      bytes_read += 512;
+      if (bytes_read >= size)
+        break;
+    }
+    cluster = fat16_get_fat_entry(cluster);
+  }
+}
+
+int fat16_write_file(const char *filename, uint8_t *data, uint32_t size) {
+  // Legacy wrapper: Seedha root mein likho
+  fat16_entry_t entry;
+  if (!fat16_find_entry(0, filename, &entry))
+    return -1;
+
+  // Create a temporary VFS node to reuse write_vfs logic
+  vfs_node_t temp_node;
+  memset(&temp_node, 0, sizeof(vfs_node_t));
+  strcpy(temp_node.name, filename);
+  temp_node.impl = (void *)(uintptr_t)entry.first_cluster_low;
+  temp_node.size = entry.file_size;
+
+  // Reuse the logic in write_vfs
+  uint32_t written = fat16_write_vfs(&temp_node, 0, size, data);
+
+  // Update directory entry size if changed
+  if (written > 0) {
+    // Key parameters phir se dhundo directory entry update karne ke liye
+    // ... Legacy root write ke liye ye aasaan hai:
+    find_ctx ctx;
+    ctx.name = filename;
+    ctx.found = false;
+    fat16_iterate_dir(0, find_callback, &ctx);
+    if (ctx.found) {
+      uint8_t buffer[512];
+      ata_read_sector(ctx.sector, buffer);
+      fat16_entry_t *e = (fat16_entry_t *)(buffer + ctx.offset);
+      e->file_size = size; // Update size
+      e->first_cluster_low =
+          (uint16_t)(uintptr_t)
+              temp_node.impl; // Update start cluster (if allocated)
+      ata_write_sector(ctx.sector, buffer);
+    }
+  }
+  return written;
+}
+
+int fat16_create_file(const char *filename) {
+  return fat16_add_entry(0, filename, ATTR_ARCHIVE, 0);
+}
+
+int fat16_mkdir(const char *name) {
+  uint16_t cluster = fat16_alloc_cluster();
+  if (cluster == 0)
+    return -1;
+
+  // Clear cluster
+  uint8_t buffer[512];
+  memset(buffer, 0, 512);
+  uint32_t sector = fat16_cluster_to_sector(cluster);
+  for (int i = 0; i < bpb.sectors_per_cluster; i++)
+    ata_write_sector(sector + i, buffer);
+
+  // Add entry to ROOT
+  return fat16_add_entry(0, name, ATTR_DIRECTORY, cluster);
+}
+
+int fat16_delete_file(const char *name) {
+  find_ctx ctx;
+  ctx.name = name;
+  ctx.found = false;
+
+  // Only supports root delete for legacy API
+  fat16_iterate_dir(0, find_callback, &ctx);
+
+  if (ctx.found) {
+    // Free Chain
+    uint16_t cluster = ctx.result.first_cluster_low;
+    while (cluster >= 2 && cluster < 0xFFF0) {
+      uint16_t next = fat16_get_fat_entry(cluster);
+      fat16_set_fat_entry(cluster, 0);
+      cluster = next;
+    }
+
+    // Mark Deleted
+    uint8_t buffer[512];
+    ata_read_sector(ctx.sector, buffer);
+    buffer[ctx.offset] = 0xE5;
+    ata_write_sector(ctx.sector, buffer);
+    return 0;
+  }
+  return -1;
+}
+
+// ============================================================================
+// VFS Bindings
+// ============================================================================
+
+static struct dirent *fat16_readdir_vfs(vfs_node_t *node, uint32_t index);
+static vfs_node_t *fat16_finddir_vfs(vfs_node_t *node, const char *name);
+static int fat16_mkdir_vfs(vfs_node_t *node, const char *name, uint32_t mask);
+static int fat16_unlink_vfs(vfs_node_t *node, const char *name);
+static int fat16_rename_vfs(vfs_node_t *node, const char *old_name,
+                            const char *new_name);
+static int fat16_create_vfs(vfs_node_t *node, const char *name, int permission);
+
+static uint32_t fat16_write_vfs(vfs_node_t *node, uint32_t offset,
+                                uint32_t size, uint8_t *buffer) {
+  // Update file size logic simplified
+  fat16_entry_t entry;
+  if (!fat16_find_entry(0, node->name, &entry)) {
+    // node->impl should suffice for writing content
+  }
+
+  uint16_t cluster = (uint16_t)(uintptr_t)node->impl;
+  if (cluster == 0) {
+    // Need to allocate first cluster!
+    cluster = fat16_alloc_cluster();
+    if (cluster == 0)
+      return 0;
+    node->impl = (void *)(uintptr_t)cluster;
+
+    // TODO: Directory entry update logic is missing parent context in VFS phase
+    // 1
+  }
+
+  uint32_t bytes_written = 0;
+  // Naive loop
+  while (cluster >= 2 && bytes_written < size) {
+    uint32_t sector = fat16_cluster_to_sector(cluster);
+    for (int i = 0; i < bpb.sectors_per_cluster && bytes_written < size; i++) {
+      uint8_t sec_buf[512];
+      uint32_t chunk =
+          (size - bytes_written) > 512 ? 512 : (size - bytes_written);
+
+      if (chunk < 512)
+        ata_read_sector(sector + i, sec_buf);
+
+      memcpy(sec_buf, buffer + bytes_written, chunk);
+      ata_write_sector(sector + i, sec_buf);
+      bytes_written += chunk;
+      if (bytes_written % (64 * 1024) == 0) {
+        serial_log("FAT16: Write Progress...");
+      }
+    }
+
+    if (bytes_written < size) {
+      uint16_t next = fat16_get_fat_entry(cluster);
+      if (next >= 0xFFF0 || next == 0) {
+        uint16_t new_c = fat16_alloc_cluster();
+        if (!new_c)
+          break;
+        fat16_set_fat_entry(cluster, new_c);
+        cluster = new_c;
+      } else {
+        cluster = next;
+      }
+    }
+  }
+  return bytes_written;
+}
+
+static uint32_t fat16_read_vfs(vfs_node_t *node, uint32_t offset, uint32_t size,
+                               uint8_t *buffer) {
+  fat16_entry_t entry;
+  entry.first_cluster_low = (uint16_t)(uintptr_t)node->impl;
+  entry.file_size = node->size;
+
+  // Full read temp buffer strategy
+  uint8_t *tmp = (uint8_t *)kmalloc((entry.file_size + 511) & ~511);
+  if (!tmp)
+    return 0;
+
+  fat16_read_file(&entry, tmp);
+
+  if (offset > entry.file_size) {
+    kfree(tmp);
+    return 0;
+  }
+  if (offset + size > entry.file_size)
+    size = entry.file_size - offset;
+
+  memcpy(buffer, tmp + offset, size);
+  kfree(tmp);
+  return size;
+}
+
+static vfs_node_t *fat16_finddir_vfs(vfs_node_t *node, const char *name) {
+  if (strcmp(name, "dev") == 0 && node->impl == 0) {
+    if (!devfs_node)
+      devfs_node = devfs_init();
+    return devfs_node;
+  }
+
+  fat16_entry_t entry;
+  if (fat16_find_entry((uint16_t)(uintptr_t)node->impl, name, &entry)) {
+    vfs_node_t *res = (vfs_node_t *)kmalloc(sizeof(vfs_node_t));
+    memset(res, 0, sizeof(vfs_node_t));
+    strcpy(res->name, name);
+    res->size = entry.file_size;
+    res->impl = (void *)(uintptr_t)entry.first_cluster_low;
+    res->read = fat16_read_vfs;
+    res->write = fat16_write_vfs;
+    res->readdir = fat16_readdir_vfs;
+    res->finddir = fat16_finddir_vfs;
+    res->mkdir = fat16_mkdir_vfs;
+    res->unlink = fat16_unlink_vfs;
+    res->rename = fat16_rename_vfs;
+    res->create = fat16_create_vfs;
+
+    if (entry.attributes & ATTR_DIRECTORY) {
+      res->flags = VFS_DIRECTORY;
+    } else {
+      res->flags = VFS_FILE;
+    }
+    return res;
+  }
+  return 0;
+}
+
+// Readdir Context State
+struct readdir_ctx {
+  uint32_t target_index;
+  uint32_t current_index;
+  fat16_entry_t *found_entry;
+};
+
+static int readdir_callback(fat16_entry_t *entry, uint32_t sector,
+                            uint32_t offset, void *d_ptr) {
+  readdir_ctx *ctx = (readdir_ctx *)d_ptr;
+
+  if (entry->filename[0] == 0)
+    return 1;
+  if ((uint8_t)entry->filename[0] == 0xE5)
+    return 0;
+  if (entry->attributes & ATTR_VOLUME_ID)
+    return 0;
+
+  if (ctx->current_index == ctx->target_index) {
+    ctx->found_entry = entry;
+    return 1;
+  }
+  ctx->current_index++;
+  return 0;
+}
+
+static struct dirent *fat16_readdir_vfs(vfs_node_t *node, uint32_t index) {
+  static struct dirent d;
+  static fat16_entry_t entry_copy;
+
+  readdir_ctx ctx;
+  ctx.target_index = index;
+  ctx.current_index = 0;
+  ctx.found_entry = 0;
+
+  fat16_iterate_dir((uint16_t)(uintptr_t)node->impl, readdir_callback, &ctx);
+
+  if (ctx.found_entry) {
+    entry_copy = *ctx.found_entry;
+    memset(&d, 0, sizeof(struct dirent));
+    fat16_to_name(d.d_name, entry_copy.filename, entry_copy.ext);
+    d.d_ino = entry_copy.first_cluster_low;
+
+    if (entry_copy.attributes & ATTR_DIRECTORY)
+      d.d_type = DT_DIR;
+    else
+      d.d_type = DT_REG;
+
+    return &d;
+  }
+  return 0;
+}
+
+static int fat16_mkdir_vfs(vfs_node_t *node, const char *name, uint32_t mask) {
+  uint16_t cluster = fat16_alloc_cluster();
+  if (cluster == 0)
+    return -1;
+
+  uint8_t buffer[512];
+  memset(buffer, 0, 512);
+  uint32_t sector = fat16_cluster_to_sector(cluster);
+  for (int i = 0; i < bpb.sectors_per_cluster; i++)
+    ata_write_sector(sector + i, buffer);
+
+  return fat16_add_entry((uint16_t)(uintptr_t)node->impl, name, ATTR_DIRECTORY,
+                         cluster);
+}
+
+static int fat16_unlink_vfs(vfs_node_t *node, const char *name) {
+  if (node->impl == 0)
+    return fat16_delete_file(name);
+  return -1;
+}
+
+static int fat16_rename_vfs(vfs_node_t *node, const char *old_name,
+                            const char *new_name) {
+  find_ctx ctx;
+  ctx.name = old_name;
+  ctx.found = false;
+  fat16_iterate_dir((uint16_t)(uintptr_t)node->impl, find_callback, &ctx);
+
+  if (!ctx.found)
+    return -1;
+
+  // New name parse
+  char filename[9];
+  char ext[4];
+  memset(filename, ' ', 8);
+  memset(ext, ' ', 3);
+  filename[8] = 0;
+  ext[3] = 0;
+
+  int fi = 0, in_ext = 0, ei = 0;
+  for (int i = 0; new_name[i]; i++) {
+    char ch = new_name[i];
+    if (ch >= 'a' && ch <= 'z')
+      ch -= 32; // Uppercase for FAT
+
+    if (ch == '.') {
+      in_ext = 1;
+      ei = 0;
+      continue;
+    }
+    if (in_ext) {
+      if (ei < 3)
+        ext[ei++] = ch;
+    } else {
+      if (fi < 8)
+        filename[fi++] = ch;
+    }
+  }
+
+  serial_log("FAT16: Updating entry to name=");
+  serial_log(filename);
+  serial_log(" ext=");
+  serial_log(ext);
+
+  uint8_t buffer[512];
+  ata_read_sector(ctx.sector, buffer);
+  fat16_entry_t *entry = (fat16_entry_t *)(buffer + ctx.offset);
+  memcpy(entry->filename, filename, 8);
+  memcpy(entry->ext, ext, 3);
+  ata_write_sector(ctx.sector, buffer);
+
+  return 0;
+}
+
+static int fat16_create_vfs(vfs_node_t *node, const char *name,
+                            int permission) {
+  return fat16_add_entry((uint16_t)(uintptr_t)node->impl, name, ATTR_ARCHIVE,
+                         0);
+}
+
+vfs_node_t *fat16_vfs_init() {
+  vfs_node_t *root = (vfs_node_t *)kmalloc(sizeof(vfs_node_t));
+  memset(root, 0, sizeof(vfs_node_t));
+  strcpy(root->name, "/");
+  root->flags = VFS_DIRECTORY;
+  root->impl = 0; // ROOT CLUSTER
+
+  root->readdir = fat16_readdir_vfs;
+  root->finddir = fat16_finddir_vfs;
+  root->read = fat16_read_vfs;
+  root->write = fat16_write_vfs;
+  root->mkdir = fat16_mkdir_vfs;
+  root->unlink = fat16_unlink_vfs;
+  root->rename = fat16_rename_vfs;
+  root->create = fat16_create_vfs;
+
+  // Initialize and mount DevFS
+  devfs_node = devfs_init();
+  devfs_node->impl = root;
+
+  return root;
+}
+}

--- a/src/drivers/fat16.h
+++ b/src/drivers/fat16.h
@@ -1,0 +1,82 @@
+#ifndef FAT16_H
+#define FAT16_H
+
+#include "../include/Std/Types.h"
+
+// FAT16 Boot Sector BPB
+typedef struct {
+  uint8_t jmp[3];
+  char oem[8];
+  uint16_t bytes_per_sector;
+  uint8_t sectors_per_cluster;
+  uint16_t reserved_sectors;
+  uint8_t fats_count;
+  uint16_t root_entries_count;
+  uint16_t total_sectors_16;
+  uint8_t media_type;
+  uint16_t sectors_per_fat;
+  uint16_t sectors_per_track;
+  uint16_t heads_count;
+  uint32_t hidden_sectors;
+  uint32_t total_sectors_32;
+  uint8_t drive_num;
+  uint8_t reserved1;
+  uint8_t boot_signature;
+  uint32_t volume_id;
+  char volume_label[11];
+  char fs_type[8];
+} __attribute__((packed)) fat16_bpb_t;
+
+// Directory Entry (32 bytes)
+typedef struct {
+  char filename[8];
+  char ext[3];
+  uint8_t attributes;
+  uint8_t reserved;
+  uint8_t create_time_tenth;
+  uint16_t create_time;
+  uint16_t create_date;
+  uint16_t last_access_date;
+  uint16_t first_cluster_high; // FAT32 only, usually 0 in FAT16
+  uint16_t write_time;
+  uint16_t write_date;
+  uint16_t first_cluster_low;
+  uint32_t file_size;
+} __attribute__((packed)) fat16_entry_t;
+
+// Attributes
+#define ATTR_READ_ONLY 0x01
+#define ATTR_HIDDEN 0x02
+#define ATTR_SYSTEM 0x04
+#define ATTR_VOLUME_ID 0x08
+#define ATTR_DIRECTORY 0x10
+#define ATTR_ARCHIVE 0x20
+#define ATTR_LFN 0x0F
+
+#include "../include/vfs.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void fat16_init();
+void fat16_set_drive(uint8_t drive);
+uint8_t fat16_get_drive();
+void fat16_list_root();
+void fat16_create_test_file();
+fat16_entry_t fat16_find_file(const char *filename);
+void fat16_read_file(fat16_entry_t *entry, uint8_t *buffer);
+int fat16_create_file(const char *filename);
+int fat16_write_file(const char *filename, uint8_t *data, uint32_t size);
+int fat16_delete_file(const char *filename);
+int fat16_mkdir(const char *name);
+void fat16_get_stats_bytes(uint32_t *total, uint32_t *free);
+
+vfs_node_t *fat16_vfs_init();
+vfs_node_t *devfs_init();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/kernel/fs_phase_a.cpp
+++ b/src/kernel/fs_phase_a.cpp
@@ -199,16 +199,63 @@ int vfs_create_file_phase_a(const char *path) {
 }
 
 int vfs_write_phase_a(phase_inode *f, const char *data, uint32_t len) {
+  return vfs_write_phase_a_at(f, data, 0, len);
+}
+
+int vfs_read_phase_a(phase_inode *f, char *out, uint32_t offset, uint32_t len) {
+  if (!f || f->type != INODE_FILE || !out)
+    return -1;
+
+  if (offset >= f->size)
+    return 0;
+
+  uint32_t to_read = len;
+  if (offset + to_read > f->size)
+    to_read = f->size - offset;
+
+  memcpy(out, phase_data_blocks[f->blocks[0]] + offset, to_read);
+  return (int)to_read;
+}
+
+int vfs_write_phase_a_at(phase_inode *f, const char *data, uint32_t offset,
+                         uint32_t len) {
   if (!f || f->type != INODE_FILE)
     return -1;
-  if (len > BLOCK_SIZE)
-    len = BLOCK_SIZE;
 
-  memcpy(phase_data_blocks[f->blocks[0]], data, len);
-  f->size = len;
+  if (offset >= BLOCK_SIZE)
+    return 0;
+
+  uint32_t to_write = len;
+  if (offset + to_write > BLOCK_SIZE)
+    to_write = BLOCK_SIZE - offset;
+
+  if (to_write > 0 && data) {
+    memcpy(phase_data_blocks[f->blocks[0]] + offset, data, to_write);
+  }
+
+  uint32_t end_pos = offset + to_write;
+  if (end_pos > f->size)
+    f->size = end_pos;
 
   phase_vfs_sync();
-  return len;
+  return (int)to_write;
+}
+
+int vfs_truncate_phase_a(phase_inode *f, uint32_t new_size) {
+  if (!f || f->type != INODE_FILE)
+    return -1;
+
+  if (new_size > BLOCK_SIZE)
+    new_size = BLOCK_SIZE;
+
+  if (new_size < f->size) {
+    memset(phase_data_blocks[f->blocks[0]] + new_size, 0, f->size - new_size);
+  }
+
+  f->size = new_size;
+
+  phase_vfs_sync();
+  return 0;
 }
 
 bool phase_vfs_rename(const char *oldpath, const char *newpath) {
@@ -301,6 +348,9 @@ extern "C" int phase_create_in_dir(phase_inode *pdir, const char *name,
 // 🔹 SECTION 10: PERSISTENCE (DISK SYNC)
 #include "../drivers/fat16.h"
 
+#define FAT16_SYSTEM_DRIVE 0
+#define FAT16_DATA_DRIVE 1
+
 // Optimization: Disable sync during bootstrap
 static bool g_phase_a_sync_enabled = true;
 
@@ -325,30 +375,73 @@ extern "C" void phase_vfs_sync() {
   offset += 4;
   memcpy(buf + offset, &phase_block_count, 4);
 
-  // Create if not exists
-  fat16_entry_t e = fat16_find_file("TRUTH.DAT");
-  if (e.filename[0] == 0) {
-    fat16_create_file("TRUTH.DAT");
-  }
+  uint8_t prev_drive = fat16_get_drive();
+  auto write_truth_on_drive = [&](uint8_t drive) {
+    fat16_set_drive(drive);
+    fat16_init();
+    fat16_entry_t e = fat16_find_file("TRUTH.DAT");
+    if (e.filename[0] == 0) {
+      fat16_create_file("TRUTH.DAT");
+    }
+    fat16_write_file("TRUTH.DAT", buf, total);
+  };
 
-  fat16_write_file("TRUTH.DAT", buf, total);
+  // Primary target: persistent data drive.
+  write_truth_on_drive(FAT16_DATA_DRIVE);
+  // Safety net: keep system drive snapshot in sync too.
+  write_truth_on_drive(FAT16_SYSTEM_DRIVE);
+
+  fat16_set_drive(prev_drive);
+  fat16_init();
   kfree(buf);
-  serial_log("FS_PHASE_A: Synced to TRUTH.DAT");
+  serial_log("FS_PHASE_A: Synced TRUTH.DAT (data+system)");
 }
 
 extern "C" void phase_vfs_load() {
-  fat16_entry_t e = fat16_find_file("TRUTH.DAT");
-  if (e.filename[0] == 0) {
-    serial_log("FS_PHASE_A: No TRUTH.DAT found, starting fresh.");
-    return;
-  }
-
   uint32_t total = phase_vfs_get_total_size();
   uint8_t *buf = (uint8_t *)kmalloc(total);
   if (!buf)
     return;
 
-  fat16_read_file(&e, buf);
+  bool loaded = false;
+  uint8_t prev_drive = fat16_get_drive();
+
+  fat16_set_drive(FAT16_DATA_DRIVE);
+  fat16_init();
+  fat16_entry_t e = fat16_find_file("TRUTH.DAT");
+
+  if (e.filename[0] != 0) {
+    fat16_read_file(&e, buf);
+    loaded = true;
+    serial_log("FS_PHASE_A: Loaded persistent state from data drive");
+  } else {
+    // One-time migration: if legacy state exists on system drive, copy to data
+    // drive.
+    fat16_set_drive(FAT16_SYSTEM_DRIVE);
+    fat16_init();
+    fat16_entry_t legacy = fat16_find_file("TRUTH.DAT");
+    if (legacy.filename[0] != 0) {
+      fat16_read_file(&legacy, buf);
+      loaded = true;
+
+      fat16_set_drive(FAT16_DATA_DRIVE);
+      fat16_init();
+      if (fat16_find_file("TRUTH.DAT").filename[0] == 0) {
+        fat16_create_file("TRUTH.DAT");
+      }
+      fat16_write_file("TRUTH.DAT", buf, total);
+      serial_log("FS_PHASE_A: Migrated TRUTH.DAT from system drive to data drive");
+    }
+  }
+
+  fat16_set_drive(prev_drive);
+  fat16_init();
+
+  if (!loaded) {
+    kfree(buf);
+    serial_log("FS_PHASE_A: No TRUTH.DAT found on data drive, starting fresh.");
+    return;
+  }
 
   uint32_t offset = 0;
   memcpy(phase_inode_table, buf + offset, sizeof(phase_inode_table));
@@ -360,31 +453,9 @@ extern "C" void phase_vfs_load() {
   memcpy(&phase_block_count, buf + offset, 4);
 
   kfree(buf);
-  serial_log("FS_PHASE_A: Loaded persistent state from TRUTH.DAT");
 }
 
-// 🔹 SECTION 11: VFS SYSTEM INTERFACE (Hooks for vfs.cpp)
-extern "C" {
-vfs_node_t *phase_a_vfs_lookup(vfs_node_t *dir, const char *name) {
-  phase_inode *parent = (phase_inode *)dir->impl;
-  if (!parent || parent->type != INODE_DIR)
-    return nullptr;
-
-  phase_dir_entry *ents =
-      (phase_dir_entry *)phase_data_blocks[parent->blocks[0]];
-  for (uint32_t i = 0; i < parent->size; i++) {
-    if (strcmp(ents[i].name, name) == 0) {
-      // Logic from wrap_phase_inode will be used in vfs.cpp
-      // But we need to return a node. This is circular.
-      // Re-implementing wrapper logic here for completeness.
-      return nullptr; // Will be handled in vfs.cpp's custom lookup
-    }
-  }
-  return nullptr;
-}
-}
-
-// 🔹 SECTION 12: BOOTSTRAP
+// 🔹 SECTION 11: BOOTSTRAP
 extern "C" void fs_phase_a_bootstrap() {
   g_phase_a_sync_enabled = false; // Disable during boot
   phase_inode_count = 0;
@@ -394,6 +465,7 @@ extern "C" void fs_phase_a_bootstrap() {
   phase_vfs_load();
 
   if (phase_inode_count > 0) {
+    g_phase_a_sync_enabled = true;
     serial_log("FS Phase A: Persistent Boot Successful.");
     return;
   }

--- a/src/kernel/syscall.cpp
+++ b/src/kernel/syscall.cpp
@@ -187,12 +187,24 @@ int sys_open(registers_t *regs) {
     return -EPERM;
 
   vfs_node_t *node = vfs_resolve_path(path);
+
+  if (!node && (flags & O_CREAT)) {
+    if (vfs_create(path, VFS_FILE) == 0) {
+      node = vfs_resolve_path(path);
+    }
+  }
+
   if (node) {
+    if ((flags & O_TRUNC) && ((flags & 3) != O_RDONLY)) {
+      uint8_t dummy = 0;
+      vfs_write(node, 0, &dummy, 0);
+    }
+
     file_description_t *desc =
         (file_description_t *)kmalloc(sizeof(file_description_t));
     desc->node = node;
     desc->flags = flags;
-    desc->offset = 0;
+    desc->offset = (flags & O_APPEND) ? node->size : 0;
     desc->ref_count = 1;
 
     for (int j = 0; j < MAX_PROCESS_FILES; j++) {
@@ -1488,7 +1500,6 @@ void init_syscalls() { register_interrupt_handler(0x80, syscall_handler); }
 
 void syscall_handler(registers_t *regs) {
   if (regs->eax < (uint32_t)num_syscalls && syscall_table[regs->eax]) {
-    serial_log_hex("SYSCALL: Called ID ", regs->eax);
     regs->eax = syscall_table[regs->eax](regs);
   } else {
     serial_log_hex("SYSCALL: Unknown ID ", regs->eax);

--- a/src/kernel/vfs.cpp
+++ b/src/kernel/vfs.cpp
@@ -195,9 +195,8 @@ static vfs_node_t *wrap_phase_inode(phase_inode *pinode, const char *name) {
     phase_inode *p = (phase_inode *)n->impl;
     if (!p || p->type != INODE_FILE)
       return 0;
-    // Simple block 0 read for now (matching Phase A implementation)
-    memcpy(buf, phase_data_blocks[p->blocks[0]] + off, sz);
-    return sz;
+    int r = vfs_read_phase_a(p, (char *)buf, off, sz);
+    return (r > 0) ? (uint32_t)r : 0;
   };
 
   node->write = [](vfs_node_t *n, uint32_t off, uint32_t sz,
@@ -205,7 +204,16 @@ static vfs_node_t *wrap_phase_inode(phase_inode *pinode, const char *name) {
     phase_inode *p = (phase_inode *)n->impl;
     if (!p || p->type != INODE_FILE)
       return 0;
-    return vfs_write_phase_a(p, (const char *)buf, sz);
+    if (sz == 0) {
+      if (vfs_truncate_phase_a(p, 0) == 0)
+        n->size = 0;
+      return 0;
+    }
+
+    int w = vfs_write_phase_a_at(p, (const char *)buf, off, sz);
+    if (w > 0 && (off + (uint32_t)w) > n->size)
+      n->size = off + (uint32_t)w;
+    return (w > 0) ? (uint32_t)w : 0;
   };
 
   node->readdir = [](vfs_node_t *n, uint32_t idx) -> struct dirent * {


### PR DESCRIPTION
Implemented true persistent storage by moving filesystem state from **RAM-only** behavior to a dedicated **virtual data disk**.

**What changed:**


- Added secondary disk based persistence using [data.img] (128MB FAT16)
- Added automatic [data.img creation and formatting in build flow when missing
- Added one-time migration from legacy system-drive state to data disk on first boot
- Updated sync flow to write [TRUTH.DAT] with data drive as primary target and system drive as safety fallback
- Added multi-drive ATA and FAT16 handling needed for selecting and accessing both disks reliably
- Updated Notepad startup behavior so default note path is reopened correctly after relaunch
- Updated run/build documentation to include dual-drive boot command

**Result:**

User files now survive VM relaunch and reboot through disk-backed persistence, not RAM-only state.